### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,10 +36,10 @@ gookme init --all
 
 ### Selectively setup Gookme
 
-If you want to only setup the hooks for a specific hook type, you can use the `--type` option of the `gookme init` command.
+If you want to only setup the hooks for a specific hook type, you can use the `--types` option of the `gookme init` command.
 
 ```bash title="Initialize Gookme with pre-commit and commit-msg hooks"
-gookme init --type pre-commit,commit-msg
+gookme init --types pre-commit,commit-msg
 ```
 
 ### Removing Gookme from your Git hooks scripts


### PR DESCRIPTION
- fix wrong type option to --types

## Description

--type option as mentioned in the getting started docs is not available. Found out that it is --types

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation