### PR TITLE
chore: replace .commitlint.yaml with .commitlintrc.yaml and update co…

### DIFF
--- a/.commitlint.yaml
+++ b/.commitlint.yaml
@@ -1,3 +1,0 @@
-settings:
-  header-max-length:
-    argument: 100

--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,4 @@
+rules:
+  header-max-length: [2, "always", 100]
+  body-max-line-length: [2, "always", 500]
+  footer-max-line-length: [2, "always", 200]

--- a/hooks/commit-msg.json
+++ b/hooks/commit-msg.json
@@ -1,8 +1,8 @@
 {
-  "steps": [
-    {
-      "name": "lint commit message",
-      "command": "commitlint lint --message $1"
-    }
-  ]
+	"steps": [
+		{
+			"name": "lint commit message",
+			"command": "commitlint --edit $1"
+		}
+	]
 }


### PR DESCRIPTION
...mmit message linting command

### Problem
- Users couldn’t write commit messages with a body and/or footer if any line exceeded 100 chars; the check was effectively applied to the whole message instead of just the title.
### Root causes
- The hook used --message $1, so commitlint treated the entire input as the header.
### Changes made
- Moved the config to a recognized filename and clarified rules
### Result
- Only the title is limited to 100 characters.
- The body and footer are limited to 500 and 200 characters, respectively, so users can write proper multi-line commit messages again.